### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
           seperator: '/'
 
       - name: Build and publish Sweetly Frontend
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           VUE_APP_URL_API: "https://api.sweetly.ca/api/"
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore